### PR TITLE
Platform chips fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,8 +38,8 @@ function App() {
             <Route path="/" element={<Navigate to="/home" />} />
             <Route path="/home" element={<HomePage keywords={searchKeywords} updateKeywords={setSearchKeywords} data={data} updateData={setData} />} />
             <Route path="/explore" element={<ExplorePage keywords={searchKeywords} updateKeywords={setSearchKeywords} data={data} updateData={setData} />} />
-            <Route path="/image/:name*" element={<RepoPage />} />
-            <Route path="/image/:name/tag/:tag*" element={<TagPage />} />
+            <Route path="/image/:name" element={<RepoPage />} />
+            <Route path="/image/:name/tag/:tag" element={<TagPage />} />
           </Route>
           <Route element={<AuthWrapper isLoggedIn={!isLoggedIn} redirect="/"/>}>
             <Route path="/login" element={<LoginPage isAuthEnabled={isAuthEnabled} setIsAuthEnabled={setIsAuthEnabled} isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn} />} />

--- a/src/api.js
+++ b/src/api.js
@@ -61,7 +61,7 @@ const api = {
 };
 
 const endpoints = {
-    imageList: '/v2/_zot/ext/search?query={RepoListWithNewestImage(){ NewestImage {RepoName Tag LastUpdated Description Platform{Os Arch} Licenses Vendor Size Labels} }}',
+    imageList: '/v2/_zot/ext/search?query={RepoListWithNewestImage(){Platforms {Os Arch}  NewestImage {RepoName Tag LastUpdated Description  Licenses Vendor Size Labels} }}',
     detailedRepoInfo: (name) => `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Images {Digest Tag Layers {Size Digest}} Summary {Name LastUpdated Size Platforms {Os Arch} Vendors NewestImage {Tag}}}}`,
     vulnerabilitiesForRepo: (name) => `/v2/_zot/ext/search?query={CVEListForImage(image: "${name}"){Tag, CVEList {Id Title Description Severity PackageList {Name InstalledVersion FixedVersion}}}}`
 }

--- a/src/components/Explore.jsx
+++ b/src/components/Explore.jsx
@@ -63,6 +63,7 @@ function Explore ({ keywords, data, updateData }) {
                         latestVersion: image.NewestImage.Tag,
                         tags: image.NewestImage.Labels,
                         description: image.NewestImage.Description,
+                        platforms: image.Platforms,
                         licenses: image.NewestImage.Licenses,
                         size: image.NewestImage.Size,
                         vendor: image.NewestImage.Vendor,
@@ -105,6 +106,7 @@ function Explore ({ keywords, data, updateData }) {
                     description={item.description}
                     tags={item.tags}
                     vendor={item.vendor}
+                    platforms={item.platforms}
                     size={item.size}
                     licenses={item.licenses}
                     key={index}

--- a/src/components/ExploreHeader.jsx
+++ b/src/components/ExploreHeader.jsx
@@ -39,7 +39,7 @@ function ExploreHeader() {
   const path = location.pathname;
   const pathWithoutImage = path.replace('tag/', '');
   const pathToBeDisplayed = pathWithoutImage.replace('/image/', '');
-  const pathHeader = pathToBeDisplayed.replace("/", " / ");
+  const pathHeader = pathToBeDisplayed.replace("/", " / ").replace('%2F','/');
   const pathWithTag = path.substring(0, path.lastIndexOf('/'));
   
   return (

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -77,7 +77,7 @@ function Home({ keywords, data, updateData }) {
               latestVersion: image.NewestImage.Tag,
               tags: image.NewestImage.Labels,
               description: image.NewestImage.Description,
-              platforms: image.NewestImage.Platform,
+              platforms: image.Platforms,
               licenses: image.NewestImage.Licenses,
               size: image.NewestImage.Size,
               vendor: image.NewestImage.Vendor,

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -77,7 +77,7 @@ function PreviewCard(props) {
   const { name } = props;
 
   const goToDetails = (repo) => {
-    navigate(`/image/${name}`);
+    navigate(`/image/${encodeURIComponent(name)}`);
   };
 
   const vulnerabilityCheck = () => {

--- a/src/components/RepoCard.jsx
+++ b/src/components/RepoCard.jsx
@@ -103,7 +103,7 @@ function RepoCard(props) {
   }
 
   const goToDetails = () => {
-    navigate(`/image/${name}`);
+    navigate(`/image/${encodeURIComponent(name)}`);
   };
 
   const vulnerabilityCheck = () => {

--- a/src/components/RepoCard.jsx
+++ b/src/components/RepoCard.jsx
@@ -129,34 +129,29 @@ function RepoCard(props) {
 
   const platformChips = () => {
     // if platforms not received, mock data
-    const platformsOsArch = platforms || [
-      "Windows",
-      "PowerPC64LE",
-      "IBM Z",
-      "Linux",
-    ];
-    return  (
-      <>
-      <Chip
-        key={platforms?.Os}
-        label={platforms?.Os}
-        sx={{
-          backgroundColor: "#E0E5EB",
-          color: "#52637A",
-          fontSize: "0.8125rem",
-        }}
-      />
-      <Chip
-        key={platforms?.Arch}
-        label={platforms?.Arch}
-        sx={{
-          backgroundColor: "#E0E5EB",
-          color: "#52637A",
-          fontSize: "0.8125rem",
-        }}
-      />
-      </>
-    );
+    const platformsOsArch = platforms || [];
+    return platformsOsArch.map((platform,index) => (
+      <Stack key={`stack${platform?.Os}${platform?.Arch}`} alignItems="center" direction="row" spacing={2}>
+        <Chip
+          key={`${name}${platform?.Os}${index}`}
+          label={platform?.Os}
+          sx={{
+            backgroundColor: "#E0E5EB",
+            color: "#52637A",
+            fontSize: "0.8125rem",
+          }}
+        />
+        <Chip
+          key={`${name}${platform?.Arch}${index}`}
+          label={platform?.Arch}
+          sx={{
+            backgroundColor: "#E0E5EB",
+            color: "#52637A",
+            fontSize: "0.8125rem",
+          }}
+        />
+      </Stack>
+    ));
   };
 
   const getVendor = () => {

--- a/src/components/RepoDetails.jsx
+++ b/src/components/RepoDetails.jsx
@@ -277,7 +277,7 @@ function RepoDetails (props) {
                       </Typography>
                       {/* {vulnerabilityCheck()}
                       {signatureCheck()} */}
-                      <BookmarkIcon sx={{color:"#52637A"}}/>
+                      {/* <BookmarkIcon sx={{color:"#52637A"}}/> */}
                     </Stack>
                     <Typography pt={1} sx={{ fontSize: 16,lineHeight:"1.5rem", color:"rgba(0, 0, 0, 0.6)", paddingLeft:"4rem"}} gutterBottom align="left">
                       {description || 'The complete solution for node.js command-line programs'}

--- a/src/components/RepoDetails.jsx
+++ b/src/components/RepoDetails.jsx
@@ -189,17 +189,30 @@ function RepoDetails (props) {
 
   
   const platformChips = () => {
-    // if platforms not received, mock data
     // @ts-ignore
-    const platforms = repoDetailData?.platforms || ["Windows","PowerPC64LE","IBM Z","Linux"];
+    const platforms = repoDetailData?.platforms || [];
 
     return platforms.map((platform, index) => (
-    
-      <Chip key={index} label={platform.Os} sx={{
-        backgroundColor: "#E0E5EB",
-        color: "#52637A",
-        fontSize: "0.8125rem",
-      }}/>
+      <Stack key={`stack${platform?.Os}${platform?.Arch}`} alignItems="center" direction="row" spacing={2}>
+        <Chip 
+          key={`${name}${platform?.Os}${index}`}
+          label={platform?.Os} 
+          sx={{
+            backgroundColor: "#E0E5EB",
+            color: "#52637A",
+            fontSize: "0.8125rem",
+          }}
+        />
+        <Chip
+          key={`${name}${platform?.Arch}${index}`}
+          label={platform?.Arch}
+          sx={{
+            backgroundColor: "#E0E5EB",
+            color: "#52637A",
+            fontSize: "0.8125rem",
+          }}
+        />
+      </Stack>
     ));
   }
 


### PR DESCRIPTION
Platforms are returned from API as an array, so when rendering them we have to map the array to the JSX code.
Also, we need to extract the data from the repo part of the returned payload, not the newest image part in order to get the full array. 

Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
